### PR TITLE
Revert "Bump uvicorn from 0.7.1 to 0.11.7"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ numpy==1.16.3
 pillow~=6.0
 python-multipart==0.0.5
 starlette==0.12.0
-uvicorn==0.11.7
+uvicorn==0.7.1


### PR DESCRIPTION
Reverts rapha18th/fastaiWebApp#1

error in production